### PR TITLE
feat: implement tap mapper pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.vscode/launch.json

--- a/map_gpt_embeddings/mappers.py
+++ b/map_gpt_embeddings/mappers.py
@@ -9,50 +9,11 @@ from singer_sdk._singerlib.messages import (
     Message,
     SchemaMessage,
 )
-from singer_sdk.authenticators import BearerTokenAuthenticator
-from singer_sdk.streams import RESTStream
-from singer_sdk.tap_base import Tap
 
 from map_gpt_embeddings.sdk_fixes.mapper_base import BasicPassthroughMapper
 from map_gpt_embeddings.sdk_fixes.messages import RecordMessage
-
-
-class TapOpenAI(Tap):
-    """OpenAI tap class."""
-
-    name = "tap-openai"
-    def discover_streams(self):
-        return []
-
-class OpenAIStream(RESTStream):
-    name = "openai"
-    path = "/v1/embeddings"
-    rest_method = "POST"
-
-    @property
-    def http_headers(self) -> dict:
-        return {
-            "Content-Type": "application/json",
-        }
-    @property
-    def authenticator(self):
-        return BearerTokenAuthenticator(stream=self, token=self.config.get("openai_api_key"))
-    
-    @property
-    def url_base(self) -> str:
-        base_url = "https://api.openai.com"
-        return base_url
-    
-    def prepare_request_payload(
-        self,
-        context,
-        next_page_token,
-    ):
-        return {
-            "input": context["text"].replace("\n", " "),
-            "model": context["model"],
-        }
-
+from map_gpt_embeddings.tap import TapOpenAI
+from map_gpt_embeddings.stream import OpenAIStream
 
 class GPTEmbeddingMapper(BasicPassthroughMapper):
     """Split documents into segments, then vectorize."""

--- a/map_gpt_embeddings/stream.py
+++ b/map_gpt_embeddings/stream.py
@@ -1,0 +1,37 @@
+import os
+
+from singer_sdk.authenticators import BearerTokenAuthenticator
+from singer_sdk.streams import RESTStream
+
+
+class OpenAIStream(RESTStream):
+    name = "openai"
+    path = "/v1/embeddings"
+    rest_method = "POST"
+
+    @property
+    def http_headers(self) -> dict:
+        return {
+            "Content-Type": "application/json",
+        }
+    @property
+    def authenticator(self):
+        return BearerTokenAuthenticator(
+            stream=self,
+            token=self.config.get("openai_api_key", os.environ.get("OPENAI_API_KEY"))
+        )
+    
+    @property
+    def url_base(self) -> str:
+        base_url = "https://api.openai.com"
+        return base_url
+    
+    def prepare_request_payload(
+        self,
+        context,
+        next_page_token,
+    ):
+        return {
+            "input": context["text"].replace("\n", " "),
+            "model": context["model"],
+        }

--- a/map_gpt_embeddings/tap.py
+++ b/map_gpt_embeddings/tap.py
@@ -3,6 +3,6 @@ from singer_sdk.tap_base import Tap
 class TapOpenAI(Tap):
     """OpenAI tap class."""
 
-    name = "tap-openai"
+    name = "map-gpt-embeddings-tap-openai"
     def discover_streams(self):
         return []

--- a/map_gpt_embeddings/tap.py
+++ b/map_gpt_embeddings/tap.py
@@ -1,0 +1,8 @@
+from singer_sdk.tap_base import Tap
+
+class TapOpenAI(Tap):
+    """OpenAI tap class."""
+
+    name = "tap-openai"
+    def discover_streams(self):
+        return []


### PR DESCRIPTION
I was running this mapper and I kept hitting the OpenAI API rate limits. The rate limits are different based on the level of your account but I'm a "pay as you go" account which is a step up from the free account so if I'm running into this then free users definitely are too.

When I run a tap-x mapper target-y and the mapper fails its a bad cycle because I have to start from scratch inevitably erroring out again. I initially wrote a little backoff logic to handle rate limiting but then realized this pattern is a solved one in the tap world. This PR is a hack and I can re-think about where to store my logic better if we like where its going but it solves an initial need for now.

I'm not sure if this is a terrible pattern but it actually worked pretty well for me. There was also a similar question in slack https://meltano.slack.com/archives/C01PKLU5D1R/p1689955015382319 recently where a user needed to tap a source to get a dataset of 200k user ids that were used as input for their actual tap so they wanted tap-x tap-y target-snowflake but thats not currently supported, this might not be a bad solution for them.

@edgarrmondragon @tayloramurphy any thoughts?